### PR TITLE
[+] Imperial bits in Metric scales

### DIFF
--- a/qt_driver.py
+++ b/qt_driver.py
@@ -24,6 +24,7 @@ Contains the main driver, using pySide or pyQt.
 from __future__ import print_function
 from future.utils import lrange
 from builtins import str
+from decimal import *
 from PIL import Image
 from PIL import PngImagePlugin
 try:
@@ -31,7 +32,7 @@ try:
 except ImportError:
     from io import  BytesIO
 
-import os, sys, traceback, webbrowser, copy, shutil
+import os, sys, traceback, webbrowser, copy, shutil, math
 
 import qt_fig
 import qt_config
@@ -1254,10 +1255,8 @@ class Driver(QtWidgets.QMainWindow):
 
         if do_screenshot:
             p_screen=QtWidgets.QApplication.primaryScreen()
-            scr_rect = p_screen.geometry();
-            image = QtGui.QScreen.grabWindow(p_screen, scr_rect.x(), scr_rect.y(), scr_rect.width(), scr_rect.height()).toImage()
-            #, scr_rect.x, scr_rect.y, scr_rect.width, scr_rect.height)
-            #.toImage()
+            image = p_screen.grabWindow(self.winId())
+
         else:
             image = self.fig.image(self.template, self.boards, self.bit, self.spacing,
                                    self.woods, self.description)
@@ -1980,6 +1979,7 @@ def run():
     '''
     Sets up and runs the application
     '''
+    getcontext().prec = 4
 #    QtGui.QApplication.setStyle('plastique')
 #    QtGui.QApplication.setStyle('windows')
 #    QtGui.QApplication.setStyle('windowsxp')

--- a/qt_test.py
+++ b/qt_test.py
@@ -67,7 +67,7 @@ class Driver_Test(unittest.TestCase):
         self.d.show()
         self.d.raise_()
         self.debug = self.d.config.debug
-        QTest.qWaitForWindowShown(self.d)
+        QTest.qWaitForWindowExposed(self.d)
         if not utils.isMac():
             self.d.working_dir = 'Z:\Windows\pyRouterJig\images'
     def test_options(self):
@@ -78,7 +78,7 @@ class Driver_Test(unittest.TestCase):
         self.assertEqual(str(self.d.le_bit_depth.text()), '3/4')
         self.assertEqual(str(self.d.le_bit_angle.text()), '0')
     def screenshot(self, do_screenshot=True):
-        QTest.qWaitForWindowShown(self.d)
+        QTest.qWaitForWindowExposed(self.d)
         QTest.qWait(100)
         self.d._on_save(do_screenshot)
     def test_screenshots(self):

--- a/router.py
+++ b/router.py
@@ -26,6 +26,7 @@ from __future__ import print_function
 from future.utils import lrange
 
 import math
+from decimal import *
 import utils
 
 class Router_Exception(Exception):
@@ -82,6 +83,14 @@ class Router_Bit(object):
 
     neck: width of bit at board surface.
 
+    midline: disstance between cuts in incremental units
+
+    depth_0: optimal depth with perfect fit
+
+    width_f: perfect width with no rounding
+
+    gap: the calculated disstance to perfect fit value
+
     halfwidth: half of width
     '''
     def __init__(self, units, width, depth, angle=0):
@@ -89,6 +98,13 @@ class Router_Bit(object):
         self.width = width
         self.depth = depth
         self.angle = angle
+
+        self.midline = Decimal('0')
+        self.depth_0 = Decimal('0')
+        self.width_f = Decimal(repr(width))
+        self.overhang = (self.width_f - self.midline) / 2
+        self.gap= Decimal('0')
+
         self.reinit()
     def set_width_from_string(self, s):
         '''
@@ -101,19 +117,21 @@ class Router_Bit(object):
         msg = 'Unable to set Bit Width to: {}<p>'\
               'Set to a positive value, such as: {}'.format(s, val)
         try:
-            width = self.units.string_to_increments(s)
+            if self.units.metric:
+                width = self.units.string_to_float(s)
+            else:
+                width = self.units.string_to_increments(s)
         except:
             raise Router_Exception(msg)
         if width <= 0:
             raise Router_Exception(msg)
-        halfwidth = width // 2
-        if 2 * halfwidth != width:
-            msg += '<p>Bit Width must be an even number of increments.<p>'\
-                   'The increment size is: {}<p>'\
-                   ''.format(self.units.increments_to_string(1, True))
-            raise Router_Exception(msg)
+        #halfwidth = width // 2
+        #if 2 * halfwidth != width:
+        #    msg += '<p>Bit Width must be an even number of increments.<p>'\
+        #           'The increment size is: {}<p>'\
+        #           ''.format(self.units.increments_to_string(1, True))
+        #    raise Router_Exception(msg)
         self.width = width
-        self.halfwidth = halfwidth
         self.reinit()
     def set_depth_from_string(self, s):
         '''
@@ -152,19 +170,19 @@ class Router_Bit(object):
         Reinitializes internal attributes that are dependent on width
         and angle.
         '''
-        self.halfwidth = self.width // 2
-        self.offset = 0 # ensure exactly 0 for angle == 0
+        self.midline = Decimal(repr(self.width))
+        self.depth_0 = Decimal(repr(self.depth))
+        self.width_f = Decimal(repr(self.width))
+
         if self.angle > 0:
-            self.offset = self.depth * math.tan(self.angle * math.pi / 180)
-        self.neck = self.width - 2 * self.offset
-    def dovetail_correction(self):
-        '''
-        Correction for rounding the offset
-        '''
-        if utils.my_round(self.neck) + 2 * utils.my_round(self.offset) < self.width:
-            return 1
-        else:
-            return 0
+            tan = Decimal(math.tan(self.angle * math.pi / 180))
+            offset = Decimal(self.depth) * tan
+            self.midline = self.width_f - offset
+            self.midline = self.midline.to_integral_value( rounding=ROUND_HALF_DOWN)
+            self.depth_0 = (self.width_f - self.midline) / tan
+
+        self.overhang = (self.width_f - self.midline) / 2
+
 
 class My_Rectangle(object):
     '''
@@ -297,29 +315,29 @@ class Board(My_Rectangle):
         x = []
         y = []
         if cuts[0].xmin > 0:
-            x = [self.xL()]
-            y = [y_nocut]
+            x = [Decimal(self.xL())]
+            y = [Decimal(y_nocut)]
         # loop through the cuts and add them to the perimeter
         for c in cuts:
             if c.xmin > 0:
                 # on the surface, start of cut
-                x.append(c.xmin + x[0] + bit.offset)
-                y.append(y_nocut)
+                x.append(c.xmin + x[0] + bit.overhang)
+                y.append(Decimal(y_nocut))
             # at the cut depth, start of cut
             x.append(c.xmin + self.xL())
-            y.append(y_cut)
+            y.append(Decimal(y_cut))
             # at the cut depth, end of cut
             x.append(c.xmax + self.xL())
-            y.append(y_cut)
+            y.append(Decimal(y_cut))
             if c.xmax < self.width:
                 # at the surface, end of cut
-                x.append(c.xmax + self.xL() - bit.offset)
-                y.append(y_nocut)
+                x.append(c.xmax + self.xL() - bit.overhang)
+                y.append(Decimal(y_nocut))
         # add the last point on the top and bottom, at the right edge,
         # accounting for whether the last cut includes this edge or not.
         if cuts[-1].xmax < self.width:
             x.append(self.xL() + self.width)
-            y.append(y_nocut)
+            y.append(Decimal(y_nocut))
         return (x, y)
     def do_all_cuts(self, bit):
         '''
@@ -473,6 +491,7 @@ class Board(My_Rectangle):
 class Cut(object):
     '''
     Cut description.
+    The cut values in Decimals to simplify rounding
 
     Attributes:
 
@@ -483,12 +502,17 @@ class Cut(object):
              on the cut
     '''
     def __init__(self, xmin, xmax):
-        self.xmin = xmin
-        self.xmax = xmax
+        self.xmin = Decimal(xmin)
+        self.xmax = Decimal(xmax)
         self.passes = []
+        #Presission value is about 1/64 inch (the exact 1/64 = 0.0156 so we fine for bouth mesument systems)
+        self.precision = Decimal('0.01')
+
     def validate(self, bit, board):
         '''
         Checks whether the attributes of the cut are valid.
+		Because we works with floating point it is yet a rounding error
+		Comparisions made with respect to precision
         '''
         if self.xmin >= self.xmax:
             raise Router_Exception('cut xmin = %d, xmax = %d: '\
@@ -500,50 +524,46 @@ class Cut(object):
             raise Router_Exception('cut xmin = %d, xmax = %d:'
                                    ' Must have xmax < board width (%d)!'\
                                    % (self.xmin, self.xmax, board.width))
-        if self.xmax - self.xmin < bit.width and self.xmin > 0 and self.xmax < board.width:
-            raise Router_Exception('cut xmin = %d, xmax = %d: '\
-                                   'Bit width (%d) too large for this cut!'\
-                                   % (self.xmin, self.xmax, bit.width))
+        if ( bit.width_f - (self.xmax - self.xmin) ) > self.precision and self.xmin > 0 and self.xmax < board.width:
+            raise Router_Exception('cut xmin = %f, xmax = %f ): '\
+                                   'Bit width (%f) delta too large for this cut!'\
+                                   % (self.xmin, self.xmax, bit.width_f))
     def make_router_passes(self, bit, board):
         '''Computes passes for the given bit.'''
-        # The logic below assumes bit.width is even
-        if bit.width % 2 != 0:
-            Router_Exception('Router-bit width must be even!')
+        # The updated logic below assumes bit.width is even for stright bits only
+
         self.validate(bit, board)
         # set current extents of the uncut region
         xL = self.xmin
         xR = self.xmax
+        bitwidth = Decimal(repr(bit.width))
+        halfwidth = bitwidth / 2
         # alternate between the left and right sides of the overall cut to make the passes
         remainder = xR - xL
         self.passes = []
         while remainder > 0:
-            # start with a pass on the right side of cut
-            p = xR - bit.halfwidth
-            if p - bit.halfwidth >= self.xmin or self.xmin == 0:
-                self.passes.append(p)
-                xR -= bit.width
-            # if anything to cut remains, do a pass on the far left side
+            p0 = utils.math_round(xR - halfwidth) # right size cut
+            p1 = utils.math_round(xL + halfwidth) # left size cut
+
+            if self.xmax <= board.width and ( self.xmin - (p0 - halfwidth) < self.precision or self.xmin == 0 ):
+                self.passes.append( int(p0) )
+
+            if p0 != p1 and ( (p1 +halfwidth) - self.xmax < self.precision or self.xmax == board.width ):
+                self.passes.append( int(p1) )
+
+            xR -= bitwidth
+            xL += bitwidth
+
             remainder = xR - xL
-            if remainder > 0:
-                p = xL + bit.halfwidth
-                if p + bit.halfwidth <= self.xmax or self.xmax == board.width:
-                    self.passes.append(p)
-                    xL += bit.width
-                    remainder = xR - xL
-                    # at this stage, we've done the same number of left and right passes, so if
-                    # there's only one more pass needed, center it.
-                    if remainder > 0 and remainder <= bit.width:
-                        p = (xL + xR) // 2
-                        self.passes.append(p)
-                        remainder = 0
+
         # Sort the passes
         self.passes = sorted(self.passes)
         # Error checking:
         for p in self.passes:
-            if (self.xmin > 0 and p - bit.halfwidth < self.xmin) or \
-               (self.xmax < board.width and p + bit.halfwidth > self.xmax):
-                raise Router_Exception('cut xmin = %d, xmax = %d, pass = %d: '\
-                                       'Bit width (%d) too large for this cut!'\
+            if (self.xmin > 0 and (self.xmin - (p - halfwidth)) > self.precision) or \
+               (self.xmax < board.width and ((p + halfwidth) - self.xmax ) > self.precision ):
+                raise Router_Exception('cut xmin = %f, xmax = %f, pass = %f: '\
+                                       'Bit width (%f) too large for this cut!'\
                                        % (self.xmin, self.xmax, p, bit.width))
 
 def adjoining_cuts(cuts, bit, board):
@@ -557,27 +577,33 @@ def adjoining_cuts(cuts, bit, board):
     Returns an array of Cut objects
     '''
     nc = len(cuts)
+    offset = bit.width_f-bit.midline
     adjCuts = []
     # if the left-most input cut does not include the left edge, add an
     # adjoining cut that includes the left edge
     if cuts[0].xmin > 0:
         left = 0
-        right = utils.my_round(cuts[0].xmin + bit.offset) - board.dheight
+        right = cuts[0].xmin + offset - board.dheight
         if right - left >= board.dheight:
-            adjCuts.append(Cut(left, right))
+            adjCuts.append( Cut( left, round(right, 4) ) )
+
     # loop through the input cuts and form an adjoining cut, formed
     # by looking where the previous cut ended and the current cut starts
     for i in lrange(1, nc):
-        left = utils.my_round(cuts[i-1].xmax - bit.offset + board.dheight)
-        right = max(left + bit.width, utils.my_round(cuts[i].xmin + bit.offset) - board.dheight)
-        adjCuts.append(Cut(left, right))
+        left = cuts[i-1].xmax - offset + board.dheight
+        right = cuts[i].xmin + offset - board.dheight
+        adjCuts.append( Cut( left, right ) )
+
     # if the right-most input cut does not include the right edge, add an
     # adjoining cut that includes this edge
     if cuts[-1].xmax < board.width:
-        left = utils.my_round(cuts[-1].xmax - bit.offset) + board.dheight
-        right = board.width
+        left = cuts[-1].xmax - offset + board.dheight
+        right = Decimal(board.width)
         if right - left >= board.dheight:
-            adjCuts.append(Cut(left, right))
+            adjCuts.append(Cut( left, right))
+	# for runtime debug only
+    #print('adjoining_cuts cuts:')
+    #dump_cuts(adjCuts)
     return adjCuts
 
 def caul_cuts(cuts, bit, board, trim):
@@ -702,66 +728,21 @@ class Joint_Geometry(object):
     def compute_fit(self):
         '''
         Sets the maximum gap and overlap over all joints.
+		The gap is already computed in the bit object
         '''
-        # Determine the board indices for each joint:
-        #     [board index top_cut, board index bottom_cut]
-        if self.boards[2].active:
-            joints = [[1, 2]]
-            if self.boards[3].active:
-                joints.append([2, 3])
-                joints.append([3, 0])
-            else:
-                joints.append([2, 0])
-        else:
-            joints = [[1, 0]]
-
-        # Load up the coordinates for the boards
-        coords = []
-        for i in range(4):
-            if self.boards[i].active:
-                coords.append(self.boards[i].do_all_cuts(self.bit))
-
-        # Determine the max gap and overlap
         self.max_gap = 0
         self.max_overlap = 0
-        for j in joints:
-            # Here, bottom and top are with respect to the joint, not the
-            # boards, so they're flipped. Roughly, should have ybot < ytop.
-            xbot = coords[j[0]][0]
-            ybot = coords[j[0]][1]
-            xtop = coords[j[1]][2]
-            ytop = coords[j[1]][3]
-            n = len(xtop)
-            yshift = self.boards[j[1]].yB() - self.boards[j[0]].yT() +\
-                     self.bit.depth
-            for i in range(n):
-                ybot[i] += yshift
-            for i in range(n - 1):
-                d = gap_overlap((xbot[i], xbot[i+1]),
-                                (ybot[i], ybot[i+1]),
-                                (xtop[i], xtop[i+1]),
-                                (ytop[i], ytop[i+1]))
-                if d > 0:
-                    self.max_gap = max(self.max_gap, d)
-                else:
-                    self.max_overlap = max(self.max_overlap, -d)
-
-def gap_overlap(xbot, ybot, xtop, ytop):
-    '''
-    Returns the distance between the midpoint of (xbot, ybot) to the 
-    line (xtop, ytop).  If positive, then a gap; otherwise, an overlap.
-    '''
-    # find unit normal from bottom line
-    dxbot = xbot[1] - xbot[0]
-    dybot = ybot[1] - ybot[0]
-    norm = 1.0 / math.sqrt(dxbot * dxbot + dybot * dybot)
-    nx = -dybot * norm
-    ny = dxbot * norm
-    # vector connecting midpoints
-    dx = 0.5 * (xtop[1] + xtop[0] - xbot[1] - xbot[0])
-    dy = 0.5 * (ytop[1] + ytop[0] - ybot[1] - ybot[0])
-    # the dot product is our result
-    return dx * nx + dy * ny
+        if self.bit.gap > 0:
+            self.max_gap = self.bit.gap
+        else:
+            self.max_overlap = -self.bit.gap
+			
+#No need such calculation anymore
+#def gap_overlap(xbot, ybot, xtop, ytop):
+#    '''
+#    Returns the distance between the midpoint of (xbot, ybot) to the 
+#    line (xtop, ytop).  If positive, then a gap; otherwise, an overlap.
+#    '''
 
 def create_title(boards, bit, spacing):
     '''

--- a/utils.py
+++ b/utils.py
@@ -23,7 +23,7 @@ This module contains base utilities for pyRouterJig
 '''
 from __future__ import division
 from __future__ import print_function
-
+from decimal import *
 import math, fractions, os, glob, platform
 
 VERSION = '0.9.3'
@@ -33,6 +33,12 @@ def my_round(f):
     Rounds to the nearest integer
     '''
     return int(round(f))
+
+def math_round(no):
+    '''
+    Return mathimatical round to integer
+    '''
+    return int(no//1 + ((no%1)/Decimal('0.5'))//1)
 
 def isMac():
     return (platform.system() == 'Darwin')
@@ -54,7 +60,7 @@ class My_Fraction(object):
         else:
             self.sign = 1
         self.whole = abs(whole)
-        self.numerator = abs(numerator)
+        self.numerator = int(abs(numerator))
         self.denominator = denominator
         self.english_separator = english_separator
     def reduce(self):
@@ -64,10 +70,13 @@ class My_Fraction(object):
         '''
         if self.denominator is None or self.numerator == 0:
             return
+		# directly convert to integer because of direct access posibility
+        self.numerator = int(self.numerator)
+        self.denominator = int(self.denominator)
         dwhole = self.numerator // self.denominator
         self.whole += dwhole
-        self.numerator -= dwhole * self.denominator
-        gcd = fractions.gcd(self.numerator, self.denominator)
+        self.numerator -= dwhole * self.denominator 
+        gcd = math.gcd(self.numerator, self.denominator)  #Python3 requres math.gcd
         self.numerator /= gcd
         self.denominator /= gcd
     def to_string(self):
@@ -175,9 +184,10 @@ class Units(object):
         '''
         A string representation of the value increments, converted to
         its respective units.
+		metric conversion requires fixed point rounding
         '''
         if self.metric:
-            r = '%g' % (increments / float(self.num_increments))
+            r = '%g' % ( Decimal(increments) / Decimal(self.num_increments) )
         else:
             allow_denoms = [1, 2, 4, 8, 16, 32, 64]
             if isinstance(increments, float):


### PR DESCRIPTION
Changes:
1 - Midline used everywhere for calculations
2 - Allow even and odd bits for dovetail joins
3 - min_finger_width respected across all functionality
4 - gap calculation optimized
5 - Midline depended on bit height ( so usually there are 2 optimal height values for a dovetail bit)
6 - qt_test got back (QT5 migration)
----------------
Fixes:
1 - Screenshot got back (QT5 fix)
2 - Mouse events for zooming got back (QT5 fix) 
3 - Save configuration fixed (typo in initial version)
4 - Application Works fine on multi-screen (up to 4 screen configuration verified)
TODO:
1 - optimize router cuts ( cuts more that half bit diameter are not welcomed), edge cuts must be delicate
2 - show optimal bit height for dovetails (bit.height_0)
3 - update signs for templates stripes showing bit info and optimal height
4 - allow reverse in variable spacing (probably it's better to put a slider for fine tune d value)
5 - Disallow fractional diameters for straight bits in metric
Limitations:
1 - Metric users must care. Fractional values allowed only for dovetails. Fractional in dovetails causes error
2 - works well on 1mm precision (other values are not well tested)
3 - Alignment line fixed to 0 (it will be fine to adopt it to edge point)